### PR TITLE
Stretches the map to fit the height of the content

### DIFF
--- a/src/components/RequestStream.vue
+++ b/src/components/RequestStream.vue
@@ -27,9 +27,9 @@
         <div id="map" class="map"></div>
         <section id="nav_buttons">
             <div id="pushToViewStreamPageButton">
-                <v-ons-button @click="fromRequest()">Join</v-ons-button>
-                <v-ons-button @click="fromRequest()">Request</v-ons-button>
-                <v-ons-button @click="fromRequest()">Create</v-ons-button>
+                <v-ons-button class="btn--join" @click="fromRequest()">Join <v-ons-icon class="btn__icon--white" icon="md-face"></v-ons-icon></v-ons-button>
+                <v-ons-button class="btn--request" @click="fromRequest()">Request <v-ons-icon class="btn__icon--white" icon="md-face"></v-ons-icon></v-ons-button>
+                <v-ons-button class="btn--create" @click="fromRequest()">Create <v-ons-icon class="btn__icon--white" icon="md-face"></v-ons-icon></v-ons-button>
             </div>
         </section>
     </div>

--- a/src/components/RequestStream.vue
+++ b/src/components/RequestStream.vue
@@ -27,7 +27,9 @@
         <div id="map" class="map"></div>
         <section id="nav_buttons">
             <div id="pushToViewStreamPageButton">
-                <v-ons-button @click="fromRequest()">Send Video Request</v-ons-button>
+                <v-ons-button @click="fromRequest()">Join</v-ons-button>
+                <v-ons-button @click="fromRequest()">Request</v-ons-button>
+                <v-ons-button @click="fromRequest()">Create</v-ons-button>
             </div>
         </section>
     </div>

--- a/src/components/RequestStream.vue
+++ b/src/components/RequestStream.vue
@@ -22,9 +22,11 @@
             </div>
         </v-ons-list-item>
     </v-ons-list>
-    <img id="vivid_logo" src="@/logo/Vivid_logo design2020-05.png" />
+    <div id="map-container">
+        <img id="vivid_logo" src="@/logo/Vivid_logo design2020-05.png" />
+        <div id="map" class="map"></div>
+    </div>
 
-    <div id="map" class="map"></div>
 
     <section id="nav_buttons">
         <div id="pushToViewStreamPageButton">

--- a/src/components/RequestStream.vue
+++ b/src/components/RequestStream.vue
@@ -25,14 +25,15 @@
     <div id="map-container">
         <img id="vivid_logo" src="@/logo/Vivid_logo design2020-05.png" />
         <div id="map" class="map"></div>
-    </div>
-
-
-    <section id="nav_buttons">
+            <section id="nav_buttons">
         <div id="pushToViewStreamPageButton">
             <v-ons-button @click="fromRequest()">Send Video Request</v-ons-button>
         </div>
     </section>
+    </div>
+
+
+
 </v-ons-page>
 </template>
 

--- a/src/components/RequestStream.vue
+++ b/src/components/RequestStream.vue
@@ -25,11 +25,11 @@
     <div id="map-container">
         <img id="vivid_logo" src="@/logo/Vivid_logo design2020-05.png" />
         <div id="map" class="map"></div>
-            <section id="nav_buttons">
-        <div id="pushToViewStreamPageButton">
-            <v-ons-button @click="fromRequest()">Send Video Request</v-ons-button>
-        </div>
-    </section>
+        <section id="nav_buttons">
+            <div id="pushToViewStreamPageButton">
+                <v-ons-button @click="fromRequest()">Send Video Request</v-ons-button>
+            </div>
+        </section>
     </div>
 
 

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -7,7 +7,7 @@ body {
 /* Desktop/Laptop Styles */
 @media all and (min-width: 414px) {
   body {
-    /*height: 736px !important;*/
+    height: 736px !important;
     width: 414px !important;
   }
 }

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -7,7 +7,7 @@ body {
 /* Desktop/Laptop Styles */
 @media all and (min-width: 414px) {
   body {
-    height: 736px !important;
+    /*height: 736px !important;*/
     width: 414px !important;
   }
 }

--- a/src/css/requestStream.css
+++ b/src/css/requestStream.css
@@ -7,7 +7,7 @@
 /* Desktop/Laptop Styles */
 @media all and (min-width: 414px) {
   #requestStreamPage {
-    height: 736px !important;
+    height: 100% !important;
     width: 414px !important;
   }
 }

--- a/src/css/requestStream.css
+++ b/src/css/requestStream.css
@@ -1,4 +1,4 @@
-#requestStreamPage {
+ #requestStreamPage {
   height: 100vh !important;
   width: 100vw !important;
   display: flex;
@@ -122,6 +122,9 @@ html,
 .page__content {
   background-color: #3daec1 !important;
   width: 100% !important;
+}
+
+#requestStreamPage .page__content {
   height: 100%;
   display: flex;
   flex-direction: column;

--- a/src/css/requestStream.css
+++ b/src/css/requestStream.css
@@ -7,7 +7,7 @@
 /* Desktop/Laptop Styles */
 @media all and (min-width: 414px) {
   #requestStreamPage {
-    height: 100% !important;
+    height: 99% !important;
     width: 414px !important;
   }
 }

--- a/src/css/requestStream.css
+++ b/src/css/requestStream.css
@@ -218,6 +218,24 @@ html,
   background-color: #1d1d1b;
   color: #16dbdb;
   font-weight: 550;
+  border-radius: 0.3rem;
+}
+#pushToViewStreamPageButton > .button  .btn__icon--white{
+  margin-left: 0.2rem;
+  color: #fff;
+}
+
+#pushToViewStreamPageButton .btn--join {
+  border: solid 1px #73E335;
+  color: #73E335;
+}
+#pushToViewStreamPageButton .btn--request {
+  border: solid 1px #49FAFC;
+  color: #49FAFC;
+}
+#pushToViewStreamPageButton .btn--create {
+  border: solid 1px #F73E2D;
+  color: #F73E2D;
 }
 
 .slimPinIcon {

--- a/src/css/requestStream.css
+++ b/src/css/requestStream.css
@@ -36,6 +36,10 @@ html,
 
 #nav_buttons {
   height: 12vh;
+  position: absolute;
+  width: 100%;
+  z-index: 9999;
+  bottom: 1rem;
   text-align: center !important;
 }
 
@@ -93,11 +97,11 @@ html,
 
 #map-container {
   flex:1;
+  position: relative;
 }
 
 #vivid_logo {
   width: 15.2%;
-  height: 7.7%;
   position: absolute;
   z-index: 1000;
   margin-top: 0%;
@@ -109,7 +113,6 @@ html,
 @media all and (min-width: 375px) and (min-height: 812px) {
   #vivid_logo {
     width: 15.2%;
-    height: 7.7%;
     position: absolute;
     z-index: 1000;
     margin-top: 0%;

--- a/src/css/requestStream.css
+++ b/src/css/requestStream.css
@@ -25,11 +25,12 @@ body {
 }
 
 html,
-/* body, */
-#map {
+ body,
+ #map
+{
   /* height: 42vh;
   width: 100vw; */
-  height: 44% !important;
+  height: 100% !important;
   width: 100% !important;
 }
 
@@ -91,11 +92,7 @@ html,
 } */
 
 #map-container {
-  /* position: relative;
-  margin-top: 0%;
-  margin-right: 0%;
-  margin-bottom: 0%;
-  margin-left: 170px; */
+  flex:1;
 }
 
 #vivid_logo {
@@ -125,6 +122,9 @@ html,
 .page__content {
   background-color: #3daec1 !important;
   width: 100% !important;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
 }
 
 .toolbar {

--- a/src/css/requestStream.css
+++ b/src/css/requestStream.css
@@ -209,12 +209,12 @@ html,
 } */
 
 #pushToViewStreamPageButton {
-  display: inline-block !important;
+  display: flex;
+  justify-content: center;
 }
 
 #pushToViewStreamPageButton > .button {
-  margin-top: 1em;
-  width: 12em;
+  margin: 1em;
   background-color: #1d1d1b;
   color: #16dbdb;
   font-weight: 550;


### PR DESCRIPTION
### Tasks ( Why )
This PR covers the first 3 tasks of https://docs.google.com/spreadsheets/d/1cpH6GNEXowum8nkFkCfbD2bioQjhJZL8FUhsnTXjnAA/edit#gid=0

Task 1: The map should fit the content page.
Task 2 -3 Replace the foot btns with 3 btns in overlay n the bottle of the map.
### How
Task 1
- Adds flex - column rules to the .page-content class
- Adds a container div to the map component that stretches it to fit the content

### Screenshots
Task 1
![ezgif com-optimize](https://user-images.githubusercontent.com/703795/85857082-10f7ef80-b7b1-11ea-99ee-82ff0a9b0909.gif)

Task 2 - 3
![Screenshot from 2020-06-29 13-32-19](https://user-images.githubusercontent.com/703795/86006017-49940500-ba0d-11ea-8183-1b495ad358fd.png)
